### PR TITLE
Add fallback for when the manifest does not exist

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,20 +1,5 @@
 <?php
 
-$finder = \PhpCsFixer\Finder::create()
-    ->in(__DIR__)
-    ->exclude([
-        'bootstrap',
-        'storage',
-        'vendor',
-    ])
-    ->name('*.php')
-    ->name('_ide_helper')
-    ->notName('*.blade.php')
-    ->notName('index.php')
-    ->notName('server.php')
-    ->ignoreDotFiles(true)
-    ->ignoreVCS(true);
-
 return (new PhpCsFixer\Config)
     ->setRiskyAllowed(true)
     ->setUsingCache(true)
@@ -125,4 +110,19 @@ return (new PhpCsFixer\Config)
         'magic_method_casing' => true, // added from Symfony
         'fully_qualified_strict_types' => true, // added
     ])
-    ->setFinder($finder);
+    ->setFinder(
+        \PhpCsFixer\Finder::create()
+            ->in(__DIR__)
+            ->exclude([
+                'bootstrap',
+                'storage',
+                'vendor',
+            ])
+            ->name('*.php')
+            ->name('_ide_helper')
+            ->notName('*.blade.php')
+            ->notName('index.php')
+            ->notName('server.php')
+            ->ignoreDotFiles(true)
+            ->ignoreVCS(true)
+    );

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Static Assets for Laravel
+
+```bash
+composer require static-assets/laravel
+```
+
+```bash
+npm install @static-assets/vite
+```
+
+```bash
+npm install @static-assets/mix
+```

--- a/config/static-assets.php
+++ b/config/static-assets.php
@@ -13,5 +13,8 @@ return [
 
         // options: disk or cache
         'save_method' => 'disk',
+
+        // amount of days to save manifest in the cache
+        'cache_days' => 30,
     ],
 ];

--- a/src/Commands/TriggerMixManifestDownload.php
+++ b/src/Commands/TriggerMixManifestDownload.php
@@ -13,7 +13,9 @@ class TriggerMixManifestDownload extends Command
 
     public function handle(): int
     {
-        (new DownloadManifest)('mix');
+        DownloadManifest::make()
+            ->forMix()
+            ->save();
 
         return Command::SUCCESS;
     }

--- a/src/Commands/TriggerViteManifestDownload.php
+++ b/src/Commands/TriggerViteManifestDownload.php
@@ -13,7 +13,9 @@ class TriggerViteManifestDownload extends Command
 
     public function handle(): int
     {
-        (new DownloadManifest)('vite');
+        DownloadManifest::make()
+            ->forVite()
+            ->save();
 
         return Command::SUCCESS;
     }

--- a/src/DownloadManifest.php
+++ b/src/DownloadManifest.php
@@ -6,10 +6,52 @@ use Illuminate\Support\Facades\Http;
 
 class DownloadManifest
 {
-    public function __invoke(string $type): void
+    protected bool $mix = false;
+
+    protected bool $vite = false;
+
+    public static function make(): self
     {
-        $fileName = $type === 'vite' ? 'manifest.json' : 'mix-manifest.json';
-        $defaultBuildDirectory = $type === 'vite' ? 'build' : '';
+        return new static();
+    }
+
+    public function forMix(): self
+    {
+        $this->vite = false;
+        $this->mix = true;
+
+        return $this;
+    }
+
+    public function forVite(): self
+    {
+        $this->vite = true;
+        $this->mix = false;
+
+        return $this;
+    }
+
+    protected function getManifest(): array
+    {
+        $response = Http::get('https://manifests.staticassets.app/'.config('static-assets.release'));
+
+        if ($response->successful()) {
+            return $response->json();
+        }
+
+        $response = Http::get('https://staticassets.app/api/manifest-fallback/'.config('static-assets.release'));
+
+        if ($response->successful()) {
+            return $response->json();
+        }
+
+        return [];
+    }
+
+    public function save(): void
+    {
+        $fileName = $this->vite ? 'manifest.json' : 'mix-manifest.json';
+        $defaultBuildDirectory = $this->vite ? 'build' : '';
         $buildDirectory = public_path(config('static-assets.manifest.custom_directory') ?: $defaultBuildDirectory);
 
         // ensure there is the build directory
@@ -17,7 +59,11 @@ class DownloadManifest
             mkdir($buildDirectory);
         }
 
-        Http::sink("{$buildDirectory}/{$fileName}")
-            ->get('https://manifests.staticassets.app/'.config('static-assets.release'));
+        file_put_contents("{$buildDirectory}/{$fileName}", json_encode($this->getManifest()));
+    }
+
+    public function toArray(): array
+    {
+        return $this->getManifest();
     }
 }

--- a/src/Mix.php
+++ b/src/Mix.php
@@ -5,7 +5,7 @@ namespace StaticAssets;
 use Exception;
 use Illuminate\Support\HtmlString;
 
-class StaticAssetMix
+class Mix
 {
     public static array $manifests = [];
 

--- a/src/Mix.php
+++ b/src/Mix.php
@@ -27,16 +27,18 @@ class Mix
             }
 
             if (! isset(static::$manifests[$manifestPath]) && config('static-assets.manifest.save_method') === 'disk') {
-                (new DownloadManifest)('mix');
+                DownloadManifest::make()
+                    ->forMix()
+                    ->save();
 
                 return $this->__invoke($path, $manifestDirectory);
             }
 
             if (config('static-assets.manifest.save_method') === 'cache') {
-                $remotePath = 'https://manifests.staticassets.app/'.config('static-assets.release');
-
-                static::$manifests[$manifestPath] = cache()->rememberForever($remotePath, function () use ($remotePath) {
-                    return json_decode(file_get_contents($remotePath), true);
+                static::$manifests[$manifestPath] = cache()->remember(config('static-assets.release'), now()->addDays(config('static-assets.manifest.cache_days')), function () {
+                    return DownloadManifest::make()
+                        ->forMix()
+                        ->toArray();
                 });
 
                 return $this->__invoke($path, $manifestDirectory);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -25,11 +25,11 @@ class ServiceProvider extends BaseServiceProvider
 
         if (config('static-assets.is_enabled')) {
             $this->app->extend(Mix::class, function () {
-                return new StaticAssetMix;
+                return new \StaticAssets\Mix;
             });
 
             $this->app->extend(Vite::class, function () {
-                return new StaticAssetVite;
+                return new \StaticAssets\Vite;
             });
         }
     }

--- a/src/Vite.php
+++ b/src/Vite.php
@@ -22,17 +22,19 @@ class Vite extends \Illuminate\Foundation\Vite
 
         // save to the disk and then continue as normal
         if (! is_file($path) && config('static-assets.manifest.save_method') === 'disk') {
-            (new DownloadManifest)('vite');
+            DownloadManifest::make()
+                ->forVite()
+                ->save();
 
             return parent::manifest($buildDirectory);
         }
 
         if (config('static-assets.manifest.save_method') === 'cache') {
             if (! isset(static::$manifests[$path])) {
-                $remotePath = 'https://manifests.staticassets.app/'.config('static-assets.release');
-
-                static::$manifests[$path] = cache()->rememberForever($remotePath, function () use ($remotePath) {
-                    return json_decode(file_get_contents($remotePath), true);
+                static::$manifests[$path] = cache()->remember(config('static-assets.release'), now()->addDays(config('static-assets.manifest.cache_days')), function () {
+                    return DownloadManifest::make()
+                        ->forVite()
+                        ->toArray();
                 });
             }
         }

--- a/src/Vite.php
+++ b/src/Vite.php
@@ -3,9 +3,8 @@
 namespace StaticAssets;
 
 use Illuminate\Support\Str;
-use Illuminate\Foundation\Vite;
 
-class StaticAssetVite extends Vite
+class Vite extends \Illuminate\Foundation\Vite
 {
     protected function assetPath($path, $secure = null): string
     {


### PR DESCRIPTION
When requesting the manifest if that fails (404) then request latest manifest from the main app using the current git hash.